### PR TITLE
feat(selection): check for id instead of reference

### DIFF
--- a/lib/features/selection/SelectionBehavior.js
+++ b/lib/features/selection/SelectionBehavior.js
@@ -2,6 +2,8 @@
 
 var hasPrimaryModifier = require('../../util/Mouse').hasPrimaryModifier;
 
+var find = require('lodash/collection/find');
+
 
 function SelectionBehavior(eventBus, selection, canvas, elementRegistry) {
 
@@ -30,11 +32,14 @@ function SelectionBehavior(eventBus, selection, canvas, elementRegistry) {
 
     // make sure at least the main moved element is being
     // selected after a move operation
-    if (shape && previousSelection.indexOf(shape) === -1) {
+    var inSelection = find(previousSelection, function(selectedShape) {
+      return shape.id === selectedShape.id;
+    });
+
+    if (!inSelection) {
       selection.select(shape);
     }
   });
-
 
   // Shift + click selection
   eventBus.on('element.click', function(event) {


### PR DESCRIPTION
Allows to re-select elements if they got replaced during dragging.

Related to bpmn-io/bpmn-js#513
